### PR TITLE
Djm link handling

### DIFF
--- a/src/assets/prosemirror-editor.css
+++ b/src/assets/prosemirror-editor.css
@@ -391,3 +391,9 @@ li[data-item-type='task'] {
 .ProseMirror a:hover {
 	text-decoration: underline;
 }
+
+/* Long press visual feedback on touch devices */
+.ProseMirror a.long-press-active {
+	color: #3794ff;
+	text-decoration: underline;
+}

--- a/src/assets/prosemirror-editor.css
+++ b/src/assets/prosemirror-editor.css
@@ -380,9 +380,11 @@ li[data-item-type='task'] {
 	margin-top: 0.15em;
 }
 
-/* Links - pointer cursor only when Ctrl/Cmd is pressed */
-.ProseMirror.ctrl-pressed a {
+/* Links - pointer cursor and blue color when Ctrl/Cmd is pressed and hovered */
+.ProseMirror.ctrl-pressed a:hover {
+	color: #4e94ce;
 	cursor: pointer;
+	text-decoration: underline;
 }
 
 /* Keep underline on links when hovering */

--- a/src/assets/prosemirror-editor.css
+++ b/src/assets/prosemirror-editor.css
@@ -53,7 +53,7 @@
 	user-select: text;
 }
 
-.ProseMirror-selectednode {
+.ProseMirror-selectednode:not(:has(a)) {
 	outline: 2px solid #8cf;
 }
 
@@ -378,4 +378,14 @@ li[data-item-type='task'] {
 .ProseMirror h5 + *,
 .ProseMirror h6 + * {
 	margin-top: 0.15em;
+}
+
+/* Links - pointer cursor only when Ctrl/Cmd is pressed */
+.ProseMirror.ctrl-pressed a {
+	cursor: pointer;
+}
+
+/* Keep underline on links when hovering */
+.ProseMirror a:hover {
+	text-decoration: underline;
 }

--- a/src/services/editor/prosemirror/checkbox-list-item-view.ts
+++ b/src/services/editor/prosemirror/checkbox-list-item-view.ts
@@ -29,6 +29,7 @@ export class CheckboxListItemView implements NodeView {
 			this.checkbox.type = 'checkbox'
 			this.checkbox.checked = node.attrs.checked
 			this.checkbox.className = 'task-checkbox'
+			this.checkbox.style.cursor = 'pointer'
 
 			// Handle checkbox changes
 			this.checkbox.addEventListener('change', this.handleCheckboxChange)

--- a/src/services/editor/prosemirror/mimiri-input-rules.ts
+++ b/src/services/editor/prosemirror/mimiri-input-rules.ts
@@ -1,12 +1,14 @@
 import {
 	ellipsis,
 	emDash,
+	InputRule,
 	inputRules,
 	smartQuotes,
 	textblockTypeInputRule,
 	wrappingInputRule,
 } from 'prosemirror-inputrules'
-import type { NodeType, Schema } from 'prosemirror-model'
+import type { MarkType, NodeType, Schema } from 'prosemirror-model'
+import { cleanUrl, urlPatternBase } from './url-utils'
 
 const blockQuoteRule = (nodeType: NodeType) => {
 	return wrappingInputRule(/^\s*>\s$/, nodeType)
@@ -35,6 +37,50 @@ const headingRule = (nodeType: NodeType, maxLevel: number) => {
 	}))
 }
 
+// Check if position already has a link mark
+const hasLinkMark = (state, pos: number, markType: MarkType): boolean => {
+	return state.doc.resolve(pos).marks().some(mark => mark.type === markType)
+}
+
+// Input rule to convert plain URLs to links when space is pressed
+const urlInputRule = (markType: MarkType) => {
+	const urlRegex = new RegExp(urlPatternBase.source + '\\s$')
+
+	return new InputRule(urlRegex, (state, match, start) => {
+		const url = cleanUrl(match[1])
+		if (hasLinkMark(state, start, markType)) return null
+
+		const urlEnd = start + url.length
+		return state.tr
+			.addMark(start, urlEnd, markType.create({ href: url }))
+			.insertText(' ', urlEnd)
+			.removeStoredMark(markType)
+	})
+}
+
+// Helper to convert URL at cursor position to link (used by Enter key handler)
+export const convertUrlAtCursor = (markType: MarkType) => {
+	return (state, dispatch) => {
+		const { $cursor } = state.selection
+		if (!$cursor) return false
+
+		const textBefore = $cursor.parent.textBetween(0, $cursor.parentOffset, undefined, '\ufffc')
+		const urlMatch = textBefore.match(new RegExp(urlPatternBase.source + '$'))
+		if (!urlMatch) return false
+
+		const url = cleanUrl(urlMatch[1])
+		const start = $cursor.pos - urlMatch[1].length
+		const end = start + url.length
+
+		if (hasLinkMark(state, start, markType)) return false
+
+		if (dispatch) {
+			dispatch(state.tr.addMark(start, end, markType.create({ href: url })))
+		}
+		return false // Allow Enter to proceed with normal action
+	}
+}
+
 export const mimiriInputRules = (schema: Schema) => {
 	const rules = smartQuotes.concat(ellipsis, emDash)
 	let type
@@ -52,6 +98,10 @@ export const mimiriInputRules = (schema: Schema) => {
 	}
 	if ((type = schema.nodes.heading)) {
 		rules.push(headingRule(type, 6))
+	}
+	let markType
+	if ((markType = schema.marks.link)) {
+		rules.push(urlInputRule(markType))
 	}
 	return inputRules({ rules })
 }

--- a/src/services/editor/prosemirror/mimiri-schema.ts
+++ b/src/services/editor/prosemirror/mimiri-schema.ts
@@ -231,7 +231,9 @@ export const marks: { [key: string]: MarkSpec } = {
 		],
 		toDOM(node) {
 			const { href, title } = node.attrs
-			return ['a', { href, title }, 0]
+			const isMac = typeof navigator !== 'undefined' && navigator.platform.includes('Mac')
+			const tooltip = title || `Follow link (${isMac ? 'Cmd' : 'Ctrl'} + click)`
+			return ['a', { href, title: tooltip }, 0]
 		},
 	},
 

--- a/src/services/editor/prosemirror/url-utils.ts
+++ b/src/services/editor/prosemirror/url-utils.ts
@@ -1,0 +1,12 @@
+// Shared URL detection and processing utilities
+
+// Base pattern for matching URLs (without anchors so it can be composed)
+export const urlPatternBase = /(https?:\/\/[^\s<>\[\]()]+)/
+
+// Trim trailing punctuation but preserve file extensions (e.g., .html, .pdf)
+export const cleanUrl = (url: string): string => {
+	while (url.length > 0 && /[.,;:!?'"]$/.test(url) && !/\.\w+$/.test(url)) {
+		url = url.slice(0, -1)
+	}
+	return url
+}


### PR DESCRIPTION
- Formats links and allows opening links using `ctrl + click` (or `cmd + click` on mac)
  - Experience generally aligned with the Monaco editor
  - A title hint appears when hovering
  - Changes to cursor-style "pointer" when `ctrl / cmd` is pressed
  - Prevents including common characters like `.` or `,` as part of the link if applied at the end
  - Fix to prevent the selected-node blue outline to apply when opening a link
- For touch devices using a long-press of 500ms to open links - ensuring editing experience is prioritized when just tabbing inside a link
- Formats links on input (after a space or enter)
- Small fix for checkboxes to also use cursor-style "pointer"
