### PR TITLE
Prosemirror styling improves

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -396,6 +396,13 @@ const handleShortcut = event => {
 			}
 		}
 	}
+	if (event.key === 'a' && ctrlActive) {
+		if (treeViewShortCutsActive) {
+			event.preventDefault()
+			event.stopPropagation()
+			mimiriEditor.selectAll()
+		}
+	}
 	if (event.key === 's' && ctrlActive) {
 		if (isSystemNote) {
 			return

--- a/src/App.vue
+++ b/src/App.vue
@@ -308,7 +308,7 @@ const handleShortcut = event => {
 		if (isSystemNote) {
 			return
 		}
-		if (treeViewShortCutsActive) {
+		if (treeViewShortCutsActive && !window.getSelection()?.toString()) {
 			event.preventDefault()
 			event.stopPropagation()
 			if (noteTreeView.value) {

--- a/src/assets/prosemirror-editor.css
+++ b/src/assets/prosemirror-editor.css
@@ -322,42 +322,42 @@ li[data-item-type='task'] {
 
 .ProseMirror h1 {
 	font-size: 1.875em;
-	margin-top: 0.5em;
+	margin-top: 0.15em;
 	font-weight: 600;
 	line-height: 1.2;
 }
 
 .ProseMirror h2 {
 	font-size: 1.5em;
-	margin-top: 0.5em;
+	margin-top: 0.15em;
 	font-weight: 600;
 	line-height: 1.25;
 }
 
 .ProseMirror h3 {
 	font-size: 1.25em;
-	margin-top: 0.4em;
+	margin-top: 0.1em;
 	font-weight: 600;
 	line-height: 1.3;
 }
 
 .ProseMirror h4 {
 	font-size: 1.125em;
-	margin-top: 0.4em;
+	margin-top: 0.1em;
 	font-weight: 600;
 	line-height: 1.35;
 }
 
 .ProseMirror h5 {
 	font-size: 1em;
-	margin-top: 0.3em;
+	margin-top: 0.1em;
 	font-weight: 600;
 	line-height: 1.4;
 }
 
 .ProseMirror h6 {
 	font-size: 0.875em;
-	margin-top: 0.3em;
+	margin-top: 0.1em;
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.05em;

--- a/src/assets/prosemirror-editor.css
+++ b/src/assets/prosemirror-editor.css
@@ -97,7 +97,7 @@
 .ProseMirror pre {
 	background-color: #2d2d2d;
 	/* mix-blend-mode: hard-light; */
-	padding: 0 0 0.25rem 0.25rem;
+	padding: 0.25rem;
 	margin: 0 0 0.5rem 0;
 	overflow-x: auto;
 }
@@ -117,7 +117,7 @@
 	display: flex;
 	font-size: 0.75rem;
 	margin-bottom: -0.125rem;
-	padding-left: 0.25rem;
+	padding: 0.25rem;
 	a {
 		color: #999999;
 		cursor: pointer;
@@ -322,44 +322,60 @@ li[data-item-type='task'] {
 
 .ProseMirror h1 {
 	font-size: 1.875em;
-	margin: 0.5em 0 0.25em;
+	margin-top: 0.5em;
 	font-weight: 600;
 	line-height: 1.2;
 }
 
 .ProseMirror h2 {
 	font-size: 1.5em;
-	margin: 0.5em 0 0.25em;
+	margin-top: 0.5em;
 	font-weight: 600;
 	line-height: 1.25;
 }
 
 .ProseMirror h3 {
 	font-size: 1.25em;
-	margin: 0.4em 0 0.2em;
+	margin-top: 0.4em;
 	font-weight: 600;
 	line-height: 1.3;
 }
 
 .ProseMirror h4 {
 	font-size: 1.125em;
-	margin: 0.4em 0 0.2em;
+	margin-top: 0.4em;
 	font-weight: 600;
 	line-height: 1.35;
 }
 
 .ProseMirror h5 {
 	font-size: 1em;
-	margin: 0.3em 0 0.15em;
+	margin-top: 0.3em;
 	font-weight: 600;
 	line-height: 1.4;
 }
 
 .ProseMirror h6 {
 	font-size: 0.875em;
-	margin: 0.3em 0 0.15em;
+	margin-top: 0.3em;
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	line-height: 1.4;
+}
+
+/* Prevents double spacing scenarios by always setting margin-top rather than combining with margin-bottom. */
+.ProseMirror h1 + *,
+.ProseMirror h2 + * {
+	margin-top: 0.4em;
+}
+
+.ProseMirror h3 + *,
+.ProseMirror h4 + * {
+	margin-top: 0.25em;
+}
+
+.ProseMirror h5 + *,
+.ProseMirror h6 + * {
+	margin-top: 0.15em;
 }

--- a/src/components/MainToolbar.vue
+++ b/src/components/MainToolbar.vue
@@ -167,15 +167,12 @@ const showMobileMenu = () => {
 	const isInRecycleBin = !!noteManager.tree.selectedNote()?.isInRecycleBin
 
 	let showShare = true
-	let showAcceptShare = true
 	if (!!noteManager.tree.selectedNote()?.isShared) {
 		const note = noteManager.tree.selectedNote()
 		showShare = note.isShareRoot
-		showAcceptShare = false
 	}
 	if (!noteManager.state.isOnline) {
 		showShare = false
-		showAcceptShare = false
 	}
 
 	const whenSelectedNote = [

--- a/src/components/NoteEditor.vue
+++ b/src/components/NoteEditor.vue
@@ -121,7 +121,7 @@
 				data-testid="editor-toggle-edit-mode-button"
 			/>
 		</div>
-		<div class="relative flex-auto flex flex-col items-stretch overflow-hidden">
+		<div class="relative flex-auto min-h-0 flex flex-col items-stretch overflow-hidden">
 			<div v-if="historyVisible && selectedHistoryItem" class="px-2 py-1 bg-info-bar cursor-default text-size-menu">
 				{{ selectedHistoryItem.username }} - {{ formatDate(selectedHistoryItem.timestamp) }} (read-only)
 			</div>
@@ -133,7 +133,7 @@
 				data-testid="editor-monaco-container"
 			/>
 			<div
-				class="overflow-hidden flex-col relative"
+				class="overflow-hidden flex-1 flex-col relative"
 				style="display: none"
 				ref="proseMirrorContainer"
 				data-testid="editor-prosemirror-container"
@@ -152,7 +152,14 @@
 					<div>History entries:</div>
 					<CloseButton @click="showHistory" class="w-6 h-6" />
 				</div>
-				<div class="flex-auto overflow-y-auto h-0 pb-5 w-full bg-input" data-testid="editor-history-scroll-container">
+				<div
+					ref="historyScrollContainer"
+					class="flex-auto overflow-y-auto h-0 pb-5 w-full bg-input"
+					data-testid="editor-history-scroll-container"
+					tabindex="0"
+					@keydown.up.prevent="navigateHistory(-1)"
+					@keydown.down.prevent="navigateHistory(1)"
+				>
 					<div class="grid grid-cols-[auto_auto_1fr] gap-x-2">
 						<template v-for="(historyItem, index) of historyItems" :key="historyItem.timestamp">
 							<div
@@ -183,7 +190,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, type WatchStopHandle } from 'vue'
+import { ref, computed, onMounted, watch, nextTick, type WatchStopHandle } from 'vue'
 import { env, infoDialog, limitDialog, mimiriEditor, noteManager, showSearchBox, titleBar } from '../global'
 import type { NoteViewModel } from '../services/types/mimer-note'
 import { searchManager } from '../services/search-manager'
@@ -198,6 +205,7 @@ import ConflictBanner from './elements/ConflictBanner.vue'
 
 let activeViewModelStopWatch: WatchStopHandle = undefined
 let activeViewModel: NoteViewModel = undefined
+const historyScrollContainer = ref<HTMLElement | null>(null)
 const monacoContainer = ref(null)
 const proseMirrorContainer = ref(null)
 const proseMirrorPopup = ref<InstanceType<typeof AutoComplete> | null>(null)
@@ -234,6 +242,22 @@ const loadMoreHistory = async () => {
 
 const selectHistoryItem = (index: number) => {
 	mimiriEditor.history.selectHistoryItem(index)
+	historyScrollContainer.value?.focus()
+}
+
+const navigateHistory = (delta: number) => {
+	const items = historyItems.value
+	if (!items?.length) return
+	const current = mimiriEditor.history.state.selectedHistoryIndex ?? 0
+	const next = Math.max(0, Math.min(items.length - 1, current + delta))
+	if (next !== current) {
+		selectHistoryItem(next)
+		void nextTick(() => {
+			historyScrollContainer.value
+				?.querySelector(`[data-testid="editor-history-item-${next}"]`)
+				?.scrollIntoView({ block: 'nearest' })
+		})
+	}
 }
 
 const checkLoadHistory = async () => {

--- a/src/components/NoteEditor.vue
+++ b/src/components/NoteEditor.vue
@@ -247,7 +247,9 @@ const selectHistoryItem = (index: number) => {
 
 const navigateHistory = (delta: number) => {
 	const items = historyItems.value
-	if (!items?.length) return
+	if (!items?.length) {
+		return
+	}
 	const current = mimiriEditor.history.state.selectedHistoryIndex ?? 0
 	const next = Math.max(0, Math.min(items.length - 1, current + delta))
 	if (next !== current) {

--- a/src/services/editor/editor-prosemirror.ts
+++ b/src/services/editor/editor-prosemirror.ts
@@ -582,7 +582,15 @@ export class EditorProseMirror implements TextEditor {
 	}
 
 	public selectAll() {
-		// document.getSelection().selectAllChildren(this._element)
+		if (this.historyShowing && this._editor) {
+			const selection = window.getSelection()
+			if (selection) {
+				const range = document.createRange()
+				range.selectNodeContents(this._editor.dom)
+				selection.removeAllRanges()
+				selection.addRange(range)
+			}
+		}
 	}
 
 	public cut() {

--- a/src/services/editor/editor-prosemirror.ts
+++ b/src/services/editor/editor-prosemirror.ts
@@ -74,7 +74,7 @@ export class EditorProseMirror implements TextEditor {
 		this._autoComplete = autoComplete
 		this._domElement.style.display = this._active ? 'flex' : 'none'
 
-		this._domElement.addEventListener('contextmenu', event => {
+		this._domElement.addEventListener('contextmenu', _event => {
 			// event.stopPropagation()
 		})
 

--- a/src/services/editor/prosemirror/checkbox-list-item-view.ts
+++ b/src/services/editor/prosemirror/checkbox-list-item-view.ts
@@ -50,10 +50,12 @@ export class CheckboxListItemView implements NodeView {
 		const checked = (event.target as HTMLInputElement).checked
 		if (!this.view.editable) {
 			;(event.target as HTMLInputElement).checked = !checked
+			this.view.focus()
 			return
 		}
 		const pos = this.getPos()
 		if (pos === undefined) {
+			this.view.focus()
 			return
 		}
 
@@ -62,6 +64,7 @@ export class CheckboxListItemView implements NodeView {
 			checked,
 		})
 		this.view.dispatch(tr)
+		this.view.focus()
 	}
 
 	update(node: Node): boolean {

--- a/src/services/editor/prosemirror/list-commands.ts
+++ b/src/services/editor/prosemirror/list-commands.ts
@@ -1,4 +1,5 @@
 import type { Node as ProseMirrorNode } from 'prosemirror-model'
+import { TextSelection } from 'prosemirror-state'
 import type { EditorState, Transaction } from 'prosemirror-state'
 import { mimiriSchema } from './mimiri-schema'
 
@@ -365,6 +366,7 @@ function createNewList(
 	// Build nested list structure based on indentation
 	const rootList = buildNestedList(blocks, targetListNodeType, targetListItemAttrs)
 	const tr = state.tr.replaceWith(startPos, endPos, rootList)
+	tr.setSelection(TextSelection.near(tr.doc.resolve(startPos + 3)))
 	dispatch(tr)
 }
 

--- a/src/services/editor/prosemirror/mimiri-deserializer.ts
+++ b/src/services/editor/prosemirror/mimiri-deserializer.ts
@@ -737,6 +737,13 @@ const buildTree = (tokens: Token[]): TreeNode => {
 			if (token.type === 'code_block' && parentType() === 'code_block') {
 				stack.pop()
 			} else {
+				// Headings (and fresh blockquotes/code blocks) are block-level and cannot
+				// be children of a list_item — pop any open list context first.
+				if (token.type === 'heading') {
+					while (isParent('list_item', 'bullet_list', 'ordered_list')) {
+						stack.pop()
+					}
+				}
 				pushChild(node)
 				stack.push(node)
 			}
@@ -776,18 +783,24 @@ const buildProseMirrorNode = (parent: TreeNode, treeNode: TreeNode, index: numbe
 			return mimiriSchema.node('doc', { indent: treeNode.indent, history }, children)
 		case 'heading':
 			return mimiriSchema.node('heading', { level: treeNode.depth || 1 }, children)
-		case 'list_item':
+		case 'list_item': {
+			// schema requires at least one paragraph child; empty items produce no tokens - causing an error
+			const listItemChildren = children.length === 0 ? [mimiriSchema.node('paragraph', null, [])] : children
 			return mimiriSchema.node(
 				'list_item',
 				{ checked: treeNode.checked, marker: treeNode.value, indent: treeNode.depth },
-				children,
+				listItemChildren,
 			)
-		case 'checkbox_item':
+		}
+		case 'checkbox_item': {
+			// schema requires at least one paragraph child; empty items produce no tokens - causing an error
+			const checkboxItemChildren = children.length === 0 ? [mimiriSchema.node('paragraph', null, [])] : children
 			return mimiriSchema.node(
 				'list_item',
 				{ checked: treeNode.checked, hideListMarker: treeNode.hideListMarker },
-				children,
+				checkboxItemChildren,
 			)
+		}
 		case 'bullet_list':
 			return mimiriSchema.node(
 				'bullet_list',

--- a/src/services/settings-manager.ts
+++ b/src/services/settings-manager.ts
@@ -2,7 +2,6 @@ import { reactive } from 'vue'
 import { fontManager, ipcClient } from '../global'
 import { menuManager } from './menu-manager'
 import { toRaw } from 'vue'
-import { mimiriPlatform } from './mimiri-platform'
 import { delay } from './helpers'
 import { emptyGuid, type Guid } from './types/guid'
 


### PR DESCRIPTION
Before:
<img width="942" height="289" alt="before" src="https://github.com/user-attachments/assets/6762c06a-8407-466b-8f4b-ca4b3d28da0d" />

After:
<img width="942" height="289" alt="after" src="https://github.com/user-attachments/assets/9ff7115d-c09d-44d2-a067-0cc55bb6c9cc" />

Fixes:
- Header sizes / spacings
- Codeblock commands spacing
- Various Checkbox related issues in prose-mirror
- History problems with spacing and keyboard navigation
- History copy and select-all issues
