### PR TITLE
Preparation localization support

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,2 +1,10 @@
 /// <reference types="vite/client" />
 declare const __DEV_VERSION__: string
+
+import type { InterpolationParams } from './src/services/localization'
+
+declare module 'vue' {
+	interface ComponentCustomProperties {
+		$t: (key: string, params?: InterpolationParams) => string
+	}
+}

--- a/src/components/dialogs/AcceptShareDialog.vue
+++ b/src/components/dialogs/AcceptShareDialog.vue
@@ -6,7 +6,7 @@
 		@close="isOpen = false"
 	>
 		<div v-if="isOpen" class="grid grid-rows-[auto_1fr_auto]">
-			<DialogTitle @close="close">Accept Share</DialogTitle>
+			<DialogTitle @close="close">{{ $t('acceptShareDialog.title') }}</DialogTitle>
 			<form @submit.prevent="submitDialog" class="mx-2 mt-5 mb-2 mobile:mx-8">
 				<div class="grid grid-cols-[4rem_10.2rem] mobile:grid-cols-[4rem_auto] items-center gap-2 mx-2 mb-2">
 					<div class="col-span-2">
@@ -15,14 +15,12 @@
 
 					<div class="col-span-2 flex flex-col items-center">
 						<div class="info mt-2">
-							<div class="text-left leading-5">Enter the one time code to accept a share.</div>
-							<div class="text-left leading-5 mt-3">
-								We do not recommend accepting shares from users you do not know.
-							</div>
+							<div class="text-left leading-5">{{ $t('acceptShareDialog.enterCode') }}</div>
+							<div class="text-left leading-5 mt-3">{{ $t('acceptShareDialog.warning') }}</div>
 						</div>
 					</div>
 					<div v-if="invalid" />
-					<div v-if="invalid" class="text-error leading-4">No share found</div>
+					<div v-if="invalid" class="text-error leading-4">{{ $t('acceptShareDialog.noShareFound') }}</div>
 					<div
 						v-if="limitsExceeded"
 						class="text-error leading-4.5 col-span-2 whitespace-pre-line"
@@ -39,9 +37,11 @@
 							@click="submitDialog"
 							data-testid="share-ok-button"
 						>
-							OK
+							{{ $t('acceptShareDialog.ok') }}
 						</button>
-						<button class="secondary" @click="close" data-testid="share-cancel-button">Cancel</button>
+						<button class="secondary" @click="close" data-testid="share-cancel-button">
+							{{ $t('acceptShareDialog.cancel') }}
+						</button>
 					</div>
 				</div>
 			</form>
@@ -51,7 +51,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { noteManager } from '../../global'
+import { noteManager, $t } from '../../global'
 import DialogTitle from '../elements/DialogTitle.vue'
 import type { MimerNote } from '../../services/types/mimer-note'
 import LoadingIcon from '../../icons/loading.vue'
@@ -103,15 +103,17 @@ const submitDialog = async () => {
 		if (error instanceof LimitError) {
 			console.error('Error accepting share:', error.limits)
 			if (error.limits.noteCount - SYSTEM_NOTE_COUNT > error.limits.maxNoteCount) {
-				limitsExceeded.value = `Cannot accept share!\nNew note count (${
-					error.limits.noteCount - SYSTEM_NOTE_COUNT
-				}) would exceed current maximum (${error.limits.maxNoteCount})`
+				limitsExceeded.value = $t('acceptShareDialog.cannotAcceptNoteCount', {
+					count: error.limits.noteCount - SYSTEM_NOTE_COUNT,
+					max: error.limits.maxNoteCount,
+				})
 			} else if (error.limits.size > error.limits.maxTotalBytes) {
-				limitsExceeded.value = `Cannot accept share!\nNew data usage (${formatBytes(
-					error.limits.size,
-				)}) would exceed current maximum (${formatBytes(error.limits.maxTotalBytes)})`
+				limitsExceeded.value = $t('acceptShareDialog.cannotAcceptDataUsage', {
+					size: formatBytes(error.limits.size),
+					max: formatBytes(error.limits.maxTotalBytes),
+				})
 			} else {
-				limitsExceeded.value = `Limit exceeded: ${error.message}`
+				limitsExceeded.value = $t('acceptShareDialog.limitExceeded', { message: error.message })
 			}
 		} else {
 			throw error

--- a/src/global.ts
+++ b/src/global.ts
@@ -15,6 +15,7 @@ import { BlogManager } from './services/blog-manager'
 import { DebugManager } from './services/debug-manager'
 import { Currency, type SubscriptionProduct } from './services/types/subscription'
 import { DevTools } from './services/dev-tools'
+import { LocalizationProvider } from './services/localization'
 
 export const env = import.meta.env
 const host = env.VITE_MIMER_API_HOST
@@ -86,6 +87,9 @@ export const mimiriEditor = new MimiriEditor()
 export const clipboardManager = new ClipboardManager()
 
 export const devTools = new DevTools(env)
+
+export const localization = new LocalizationProvider()
+export const $t = localization.t.bind(localization)
 
 export const features = []
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1,0 +1,13 @@
+{
+	"acceptShareDialog": {
+		"title": "Accept Share",
+		"enterCode": "Enter the one time code to accept a share.",
+		"warning": "We do not recommend accepting shares from users you do not know.",
+		"noShareFound": "No share found",
+		"ok": "OK",
+		"cancel": "Cancel",
+		"cannotAcceptNoteCount": "Cannot accept share!\nNew note count ({count}) would exceed current maximum ({max})",
+		"cannotAcceptDataUsage": "Cannot accept share!\nNew data usage ({size}) would exceed current maximum ({max})",
+		"limitExceeded": "Limit exceeded: {message}"
+	}
+}

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -1,0 +1,13 @@
+{
+	"acceptShareDialog": {
+		"title": "接受分享",
+		"enterCode": "请输入一次性验证码以接受分享。",
+		"warning": "我们不建议接受来自陌生用户的分享。",
+		"noShareFound": "未找到分享",
+		"ok": "确定",
+		"cancel": "取消",
+		"cannotAcceptNoteCount": "无法接受分享！\n新笔记数量（{count}）将超过当前上限（{max}）",
+		"cannotAcceptDataUsage": "无法接受分享！\n新数据用量（{size}）将超过当前上限（{max}）",
+		"limitExceeded": "已超出限制：{message}"
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,9 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import App from './App.vue'
+import { $t, localization } from './global'
+import enLocale from './lang/en.json'
+import zhLocale from './lang/zh.json'
 import { initializeMonacoThemes } from './services/editor/theme-manager'
 import { initializeTextMateGrammars } from './services/editor/textmate-setup'
 
@@ -32,8 +35,10 @@ import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 	},
 }
 
-// Initialize TextMate grammars and Monaco themes before creating the app
+// Initialize localization, TextMate grammars and Monaco themes before creating the app
 async function initializeEditor() {
+	localization.register('en', enLocale)
+	localization.register('zh', zhLocale)
 	// Initialize TextMate grammars first (required for Monaco themes to work with TextMate)
 	await initializeTextMateGrammars()
 
@@ -42,6 +47,7 @@ async function initializeEditor() {
 
 	// Finally mount the app
 	const app = createApp(App)
+	app.config.globalProperties.$t = $t
 	app.mount('#app')
 }
 

--- a/src/services/localization.test.ts
+++ b/src/services/localization.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from '@jest/globals'
+import { LocalizationProvider, type LocaleData } from './localization'
+
+const enLocale: LocaleData = {
+	common: {
+		ok: 'OK',
+		cancel: 'Cancel',
+		delete: 'Delete',
+		close: 'Close',
+	},
+	acceptShareDialog: {
+		title: 'Accept Share',
+		enterCode: 'Enter the one time code to accept a share.',
+		noShareFound: 'No share found',
+		cannotAcceptNoteCount: 'Cannot accept share!\nNew note count ({count}) would exceed current maximum ({max})',
+		cannotAcceptDataUsage: 'Cannot accept share!\nNew data usage ({size}) would exceed current maximum ({max})',
+		limitExceeded: 'Limit exceeded: {message}',
+	},
+	shareDialog: {
+		title: 'Share Note',
+		instruction: 'Share this one time code with {name} to complete the share of {noteName}',
+		_comment: 'Shown after a share code has been generated',
+	},
+	deleteNodeDialog: {
+		title: 'Delete Note',
+		confirm: 'Are you sure you want to delete:',
+		leaveShareTitle: 'Leave Share',
+		remainsAccessibleTo: 'This note will remain be accessible to:',
+	},
+}
+
+const zhLocale: LocaleData = {
+	common: {
+		ok: '确定',
+		cancel: '取消',
+	},
+	acceptShareDialog: {
+		title: '接受分享',
+		noShareFound: '未找到分享',
+	},
+}
+
+describe('LocalizationProvider', () => {
+	let provider: LocalizationProvider
+
+	beforeEach(() => {
+		provider = new LocalizationProvider()
+		provider.register('en', enLocale)
+		provider.register('zh', zhLocale)
+		provider.setFallbackLocale('en')
+		provider.setLocale('en')
+	})
+
+	describe('t()', () => {
+		it('returns a top-level string value', () => {
+			expect(provider.t('common.ok')).toBe('OK')
+		})
+
+		it('returns a deeply nested string value', () => {
+			expect(provider.t('acceptShareDialog.enterCode')).toBe('Enter the one time code to accept a share.')
+		})
+
+		it('returns the key itself when the key is not found', () => {
+			expect(provider.t('common.doesNotExist')).toBe('common.doesNotExist')
+		})
+
+		it('returns the key itself when the namespace is not found', () => {
+			expect(provider.t('nonexistent.key')).toBe('nonexistent.key')
+		})
+
+		it('interpolates single placeholder', () => {
+			expect(provider.t('acceptShareDialog.limitExceeded', { message: 'quota reached' })).toBe(
+				'Limit exceeded: quota reached',
+			)
+		})
+
+		it('interpolates multiple placeholders', () => {
+			expect(provider.t('acceptShareDialog.cannotAcceptNoteCount', { count: 150, max: 100 })).toBe(
+				'Cannot accept share!\nNew note count (150) would exceed current maximum (100)',
+			)
+		})
+
+		it('interpolates two placeholders in share instruction', () => {
+			expect(provider.t('shareDialog.instruction', { name: 'alice', noteName: 'My Notes' })).toBe(
+				'Share this one time code with alice to complete the share of My Notes',
+			)
+		})
+
+		it('leaves unknown placeholders unchanged', () => {
+			expect(provider.t('acceptShareDialog.cannotAcceptNoteCount')).toBe(
+				'Cannot accept share!\nNew note count ({count}) would exceed current maximum ({max})',
+			)
+		})
+
+		it('treats _comment keys as regular strings', () => {
+			expect(provider.t('shareDialog._comment')).toBe('Shown after a share code has been generated')
+		})
+
+		it('returns key when resolving an intermediate object node', () => {
+			expect(provider.t('common')).toBe('common')
+		})
+	})
+
+	describe('has()', () => {
+		it('returns true for an existing key', () => {
+			expect(provider.has('common.ok')).toBe(true)
+		})
+
+		it('returns false for a missing key', () => {
+			expect(provider.has('common.nonexistent')).toBe(false)
+		})
+
+		it('returns false for intermediate object nodes', () => {
+			expect(provider.has('common')).toBe(false)
+		})
+
+		it('returns true for _comment keys', () => {
+			expect(provider.has('shareDialog._comment')).toBe(true)
+		})
+	})
+
+	describe('fallback locale', () => {
+		beforeEach(() => {
+			provider.setLocale('zh')
+		})
+
+		it('returns the current locale value when key exists in it', () => {
+			expect(provider.t('common.ok')).toBe('确定')
+		})
+
+		it('falls back to the fallback locale when key is missing in current locale', () => {
+			expect(provider.t('common.delete')).toBe('Delete')
+		})
+
+		it('falls back for deeply nested keys', () => {
+			expect(provider.t('acceptShareDialog.enterCode')).toBe('Enter the one time code to accept a share.')
+		})
+
+		it('has() returns true for keys only in fallback locale', () => {
+			expect(provider.has('common.delete')).toBe(true)
+		})
+	})
+
+	describe('setLocale() and currentLocale', () => {
+		it('reports the current locale', () => {
+			provider.setLocale('zh')
+			expect(provider.currentLocale).toBe('zh')
+		})
+
+		it('reports the fallback locale', () => {
+			provider.setFallbackLocale('zh')
+			expect(provider.fallbackLocale).toBe('zh')
+		})
+	})
+
+	describe('unregistered locale', () => {
+		it('falls back gracefully when the current locale has no registered data', () => {
+			provider.setLocale('fr')
+			expect(provider.t('common.ok')).toBe('OK')
+		})
+	})
+})

--- a/src/services/localization.ts
+++ b/src/services/localization.ts
@@ -1,0 +1,75 @@
+import { reactive } from 'vue'
+
+export type LocaleScalar = string
+
+export interface LocaleData {
+	[key: string]: LocaleScalar | LocaleData
+}
+
+export type InterpolationParams = Record<string, string | number>
+
+export class LocalizationProvider {
+	private locales = new Map<string, LocaleData>()
+	private state = reactive({ currentLocale: 'en', fallbackLocale: 'en' })
+
+	register(locale: string, data: LocaleData): void {
+		this.locales.set(locale, data)
+	}
+
+	setLocale(locale: string): void {
+		this.state.currentLocale = locale
+	}
+
+	setFallbackLocale(locale: string): void {
+		this.state.fallbackLocale = locale
+	}
+
+	get currentLocale(): string {
+		return this.state.currentLocale
+	}
+
+	get fallbackLocale(): string {
+		return this.state.fallbackLocale
+	}
+
+	has(key: string): boolean {
+		return (
+			this.resolve(key, this.state.currentLocale) !== undefined ||
+			this.resolve(key, this.state.fallbackLocale) !== undefined
+		)
+	}
+
+	/** Translate a key to a string. Placeholders in the form {name} are replaced by params. */
+	t(key: string, params?: InterpolationParams): string {
+		const value = this.resolve(key, this.state.currentLocale) ?? this.resolve(key, this.state.fallbackLocale)
+
+		if (value === undefined) return key
+		if (typeof value !== 'string') return key
+
+		return this.interpolate(value, params)
+	}
+
+	private resolve(key: string, locale: string): LocaleScalar | undefined {
+		const data = this.locales.get(locale)
+		if (!data) return undefined
+
+		const parts = key.split('.')
+		let current: LocaleScalar | LocaleData = data
+
+		for (const part of parts) {
+			if (typeof current !== 'object' || Array.isArray(current)) return undefined
+			const next = (current as LocaleData)[part]
+			if (next === undefined) return undefined
+			current = next
+		}
+
+		if (typeof current === 'object' && !Array.isArray(current)) return undefined
+
+		return current as LocaleScalar
+	}
+
+	private interpolate(template: string, params?: InterpolationParams): string {
+		if (!params) return template
+		return template.replace(/\{(\w+)\}/g, (match, key: string) => (key in params ? String(params[key]) : match))
+	}
+}


### PR DESCRIPTION
Preparation for localization support

- Adds basic localization support using a json file with a nested key-value structure
  - `$t` is exposed in vue files and can be used directly for translations into the currently selected language
- This PR does not enable any localization, English remains the only supported language for now
  - `zh.json` is only added for testing purposes
  - Accept Share Dialog has been converted to use localization (but only using EN values) as a proof of concept