### PR TITLE
Adds inline code support and fixes div. prosemirror code block related issues

### DIFF
--- a/src/assets/monaco-editor.css
+++ b/src/assets/monaco-editor.css
@@ -180,6 +180,24 @@
 	font-style: italic;
 }
 
+/* Inline code */
+.inline-code-delimiter {
+	opacity: 0.4;
+	color: #888888;
+}
+.monaco-editor.vs-dark .inline-code-delimiter {
+	color: #eeeeee;
+}
+
+.monaco-editor .md-inline-code {
+	background-color: rgba(175, 184, 193, 0.2);
+	/* Note: Only background color to avoid cursor position issues in Monaco */
+	/* Font changes (family, size) can cause cursor misalignment */
+}
+.monaco-editor.vs-dark .md-inline-code {
+	background-color: rgba(110, 118, 129, 0.4);
+}
+
 /* Conflict block styling - Local vs Server */
 .monaco-editor .conflict-marker-line {
 	background-color: #eeeeee;

--- a/src/assets/prosemirror-editor.css
+++ b/src/assets/prosemirror-editor.css
@@ -28,10 +28,18 @@
 }
 
 .ProseMirror ::selection {
-	background-color: #264f78;
+	background-color: #add6ff;
 }
 
 .ProseMirror ::-moz-selection {
+	background-color: #add6ff;
+}
+
+html[data-theme='dark'] .ProseMirror ::selection {
+	background-color: #264f78;
+}
+
+html[data-theme='dark'] .ProseMirror ::-moz-selection {
 	background-color: #264f78;
 }
 
@@ -95,15 +103,29 @@
 
 /* Code blocks */
 .ProseMirror pre {
-	background-color: #2d2d2d;
-	/* mix-blend-mode: hard-light; */
+	background-color: #f5f5f5;
 	padding: 0.25rem;
 	margin: 0 0 0.5rem 0;
 	overflow-x: auto;
 }
 
+html[data-theme='dark'] .ProseMirror pre {
+	background-color: #2d2d2d;
+}
+
+/* Inline code */
 .ProseMirror code {
+	font-family: Consolas, 'Courier New', monospace;
 	font-size: 0.9em;
+	background-color: rgba(175, 184, 193, 0.2);
+	padding: 0.1em 0.3em;
+	margin: 0;
+	border-radius: 3px;
+}
+
+/* Dark mode inline code */
+html[data-theme='dark'] .ProseMirror code {
+	background-color: rgba(110, 118, 129, 0.4);
 }
 
 .ProseMirror pre code {
@@ -111,6 +133,13 @@
 	font-size: 14px;
 	background: none;
 	padding: 0;
+	border-radius: 0;
+	white-space: pre-wrap;
+}
+
+/* Ensure code blocks don't get inline code background in dark mode */
+html[data-theme='dark'] .ProseMirror pre code {
+	background: none;
 }
 
 .ProseMirror codelens {

--- a/src/lang/context.json
+++ b/src/lang/context.json
@@ -209,7 +209,7 @@
 		"showHistory": "Toggle button label when history panel is closed.",
 		"markAsPassword": "Toolbar button tooltip — formats selected text as masked password text. Keyboard shortcut is appended in the English string.",
 		"heading": "Toolbar button: insert/format a heading.",
-		"codeBlock": "Toolbar button: insert a code block.",
+		"codeBlock": "Toolbar button: mark single-line selection as inline code, or wrap multi-line selection/insert code block.",
 		"checkbox": "Toolbar button: insert a checkbox.",
 		"list": "Toolbar button: insert an unordered list.",
 		"orderedList": "Toolbar button: insert an ordered/numbered list.",

--- a/src/lang/da.json
+++ b/src/lang/da.json
@@ -191,7 +191,7 @@
 		"showHistory": "Vis historik",
 		"markAsPassword": "Marker som adgangskode Ctrl+Shift+C",
 		"heading": "Overskrift",
-		"codeBlock": "Kodeblok",
+		"codeBlock": "Marker valgt tekst som kode, eller indsæt kodeblok",
 		"checkbox": "Afkrydsningsfelt",
 		"list": "Liste",
 		"orderedList": "Nummereret liste",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -191,7 +191,7 @@
 		"showHistory": "Verlauf anzeigen",
 		"markAsPassword": "Als Passwort markieren Strg+Umschalt+C",
 		"heading": "Überschrift",
-		"codeBlock": "Codeblock",
+		"codeBlock": "Markierten Text als Code markieren oder Codeblock einfügen",
 		"checkbox": "Kontrollkästchen",
 		"list": "Liste",
 		"orderedList": "Nummerierte Liste",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -191,7 +191,7 @@
 		"showHistory": "Show History",
 		"markAsPassword": "Mark as Password Ctrl+Shift+C",
 		"heading": "Heading",
-		"codeBlock": "Code Block",
+		"codeBlock": "Mark selected text as code, or insert code block",
 		"checkbox": "Checkbox",
 		"list": "List",
 		"orderedList": "Ordered List",

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -191,7 +191,7 @@
 		"showHistory": "显示历史记录",
 		"markAsPassword": "标记为密码 Ctrl+Shift+C",
 		"heading": "标题",
-		"codeBlock": "代码块",
+		"codeBlock": "将选定文本标记为代码，或插入代码块",
 		"checkbox": "复选框",
 		"list": "列表",
 		"orderedList": "有序列表",

--- a/src/services/editor/editor-monaco.ts
+++ b/src/services/editor/editor-monaco.ts
@@ -167,6 +167,10 @@ export class EditorMonaco implements TextEditor {
 				if (e.keyCode === KeyCode.KeyF && e.ctrlKey && e.shiftKey) {
 					this.listener.onSearchAllRequested()
 				}
+				if (e.keyCode === KeyCode.KeyE && e.ctrlKey) {
+					e.preventDefault()
+					this.executeFormatAction('insert-code-block')
+				}
 			}
 		})
 

--- a/src/services/editor/editor-prosemirror.ts
+++ b/src/services/editor/editor-prosemirror.ts
@@ -14,6 +14,7 @@ import {
 	liftEmptyBlock,
 	newlineInCode,
 	splitBlock,
+	toggleMark,
 } from 'prosemirror-commands'
 import { mimiriSchema } from './prosemirror/mimiri-schema'
 import { convertUrlAtCursor, mimiriInputRules } from './prosemirror/mimiri-input-rules'
@@ -33,7 +34,7 @@ import { ConflictActionHandler } from './prosemirror/conflict-action-handler'
 import { createPasswordMarkViewFactory } from './prosemirror/password-mark-view'
 import { passwordCursorPlugin } from './prosemirror/password-cursor-plugin'
 import type ConflictBanner from '../../components/elements/ConflictBanner.vue'
-import { executeFormatAction, getSupportedActions } from './prosemirror/format-commands'
+import { executeFormatAction, getSupportedActions, exitCodeBlock } from './prosemirror/format-commands'
 
 export class EditorProseMirror implements TextEditor {
 	private _domElement: HTMLElement | undefined
@@ -126,7 +127,9 @@ export class EditorProseMirror implements TextEditor {
 				keymap({
 					'Mod-z': undo,
 					'Mod-y': redo,
+					'Mod-e': toggleMark(mimiriSchema.marks.code),
 					Enter: chainCommands(
+						exitCodeBlock,
 						convertUrlAtCursor(mimiriSchema.marks.link),
 						splitListItem(mimiriSchema.nodes.list_item),
 					),

--- a/src/services/editor/editor-prosemirror.ts
+++ b/src/services/editor/editor-prosemirror.ts
@@ -14,7 +14,6 @@ import {
 	liftEmptyBlock,
 	newlineInCode,
 	splitBlock,
-	toggleMark,
 } from 'prosemirror-commands'
 import { mimiriSchema } from './prosemirror/mimiri-schema'
 import { convertUrlAtCursor, mimiriInputRules } from './prosemirror/mimiri-input-rules'
@@ -127,7 +126,12 @@ export class EditorProseMirror implements TextEditor {
 				keymap({
 					'Mod-z': undo,
 					'Mod-y': redo,
-					'Mod-e': toggleMark(mimiriSchema.marks.code),
+					'Mod-e': (state, dispatch) => {
+						if (dispatch) {
+							executeFormatAction(state, dispatch, 'insert-code-block')
+						}
+						return true
+					},
 					Enter: chainCommands(
 						exitCodeBlock,
 						convertUrlAtCursor(mimiriSchema.marks.link),

--- a/src/services/editor/monaco-editor/code-block-plugin.ts
+++ b/src/services/editor/monaco-editor/code-block-plugin.ts
@@ -410,7 +410,6 @@ export class CodeBlockPlugin implements EditorPlugin {
 			// Check if selection is single-line and not empty
 			if (!selection.isEmpty() && selection.startLineNumber === selection.endLineNumber) {
 				// Apply inline code formatting
-				const selectedText = this.monacoEditorModel.getValueInRange(selection)
 
 				// Check if already wrapped in backticks - if so, remove them
 				const line = this.monacoEditorModel.getLineContent(selection.startLineNumber)
@@ -486,11 +485,20 @@ export class CodeBlockPlugin implements EditorPlugin {
 				endColumn: this.monacoEditorModel.getLineMaxColumn(selection.endLineNumber),
 			}
 			if (selection.isEmpty()) {
-				// Insert code block and position cursor for language input
+				// Get the current line content to preserve it in the code block
+				const lineContent = this.monacoEditorModel.getLineContent(selection.startLineNumber)
+				const lineRange = {
+					startLineNumber: selection.startLineNumber,
+					startColumn: 1,
+					endLineNumber: selection.startLineNumber,
+					endColumn: this.monacoEditorModel.getLineMaxColumn(selection.startLineNumber),
+				}
+
+				// Replace the entire line with a code block containing the line's content
 				this.monacoEditor.executeEdits(undefined, [
 					{
-						range: selection,
-						text: '```\n\n```\n',
+						range: lineRange,
+						text: lineContent ? `\`\`\`\n${lineContent}\n\`\`\`` : '```\n\n```',
 					},
 				])
 

--- a/src/services/editor/monaco-editor/code-block-plugin.ts
+++ b/src/services/editor/monaco-editor/code-block-plugin.ts
@@ -406,6 +406,80 @@ export class CodeBlockPlugin implements EditorPlugin {
 	executeFormatAction(action: string): boolean {
 		if (action === 'insert-code-block') {
 			const selection = this.monacoEditor.getSelection()
+
+			// Check if selection is single-line and not empty
+			if (!selection.isEmpty() && selection.startLineNumber === selection.endLineNumber) {
+				// Apply inline code formatting
+				const selectedText = this.monacoEditorModel.getValueInRange(selection)
+
+				// Check if already wrapped in backticks - if so, remove them
+				const line = this.monacoEditorModel.getLineContent(selection.startLineNumber)
+				const charBefore = selection.startColumn > 1 ? line[selection.startColumn - 2] : ''
+				const charAfter = selection.endColumn <= line.length ? line[selection.endColumn - 1] : ''
+
+				if (charBefore === '`' && charAfter === '`') {
+					// Remove backticks
+					this.monacoEditor.executeEdits(undefined, [
+						{
+							range: {
+								startLineNumber: selection.startLineNumber,
+								startColumn: selection.endColumn,
+								endLineNumber: selection.endLineNumber,
+								endColumn: selection.endColumn + 1,
+							},
+							text: '',
+						},
+						{
+							range: {
+								startLineNumber: selection.startLineNumber,
+								startColumn: selection.startColumn - 1,
+								endLineNumber: selection.startLineNumber,
+								endColumn: selection.startColumn,
+							},
+							text: '',
+						},
+					])
+					// Adjust selection
+					this.monacoEditor.setSelection({
+						startLineNumber: selection.startLineNumber,
+						startColumn: selection.startColumn - 1,
+						endLineNumber: selection.endLineNumber,
+						endColumn: selection.endColumn - 1,
+					})
+				} else {
+					// Add backticks
+					this.monacoEditor.executeEdits(undefined, [
+						{
+							range: {
+								startLineNumber: selection.endLineNumber,
+								startColumn: selection.endColumn,
+								endLineNumber: selection.endLineNumber,
+								endColumn: selection.endColumn,
+							},
+							text: '`',
+						},
+						{
+							range: {
+								startLineNumber: selection.startLineNumber,
+								startColumn: selection.startColumn,
+								endLineNumber: selection.startLineNumber,
+								endColumn: selection.startColumn,
+							},
+							text: '`',
+						},
+					])
+					// Adjust selection to include backticks
+					this.monacoEditor.setSelection({
+						startLineNumber: selection.startLineNumber,
+						startColumn: selection.startColumn + 1,
+						endLineNumber: selection.endLineNumber,
+						endColumn: selection.endColumn + 1,
+					})
+				}
+				return true
+			}
+
+			// Multi-line or empty selection - insert code block
 			const expandedSelection = {
 				...selection,
 				startColumn: 1,

--- a/src/services/editor/monaco-editor/inline-markdown-plugin.ts
+++ b/src/services/editor/monaco-editor/inline-markdown-plugin.ts
@@ -143,6 +143,12 @@ export class InlineMarkdownPlugin implements EditorPlugin {
 			const checkboxMatches = this.findCheckboxPatterns(line, lineNumber)
 			decorations.push(...checkboxMatches)
 
+			// Check for inline code pattern (but not code fences)
+			if (!line.trim().startsWith('```')) {
+				const inlineCodeMatches = this.findInlineCodePatterns(line, lineNumber)
+				decorations.push(...inlineCodeMatches)
+			}
+
 			// Check for bold/italic patterns (only if not in a heading)
 			if (headingMatches.length === 0) {
 				const textStyleMatches = this.findTextStylePatterns(line, lineNumber)
@@ -235,6 +241,60 @@ export class InlineMarkdownPlugin implements EditorPlugin {
 				},
 				options: {
 					inlineClassName: 'password-delimiter',
+				},
+			})
+		}
+
+		return decorations
+	}
+
+	private findInlineCodePatterns(line: string, lineNumber: number): editor.IModelDeltaDecoration[] {
+		const decorations: editor.IModelDeltaDecoration[] = []
+		// Match single backticks that are not part of password pattern (p`) or code fences (```)
+		const regex = /(?<!p)(`([^`\n]+)`)/g
+		let match: RegExpExecArray | null
+
+		while ((match = regex.exec(line)) !== null) {
+			const startCol = match.index + 1
+			const contentLength = match[2].length
+			const contentStartCol = startCol + 1 // After opening backtick
+
+			// Opening backtick
+			decorations.push({
+				range: {
+					startLineNumber: lineNumber,
+					startColumn: startCol,
+					endLineNumber: lineNumber,
+					endColumn: startCol + 1,
+				},
+				options: {
+					inlineClassName: 'inline-code-delimiter',
+				},
+			})
+
+			// Content
+			decorations.push({
+				range: {
+					startLineNumber: lineNumber,
+					startColumn: contentStartCol,
+					endLineNumber: lineNumber,
+					endColumn: contentStartCol + contentLength,
+				},
+				options: {
+					inlineClassName: 'md-inline-code',
+				},
+			})
+
+			// Closing backtick
+			decorations.push({
+				range: {
+					startLineNumber: lineNumber,
+					startColumn: contentStartCol + contentLength,
+					endLineNumber: lineNumber,
+					endColumn: contentStartCol + contentLength + 1,
+				},
+				options: {
+					inlineClassName: 'inline-code-delimiter',
 				},
 			})
 		}

--- a/src/services/editor/prosemirror/format-commands.ts
+++ b/src/services/editor/prosemirror/format-commands.ts
@@ -1,7 +1,7 @@
 import type { EditorState, Transaction } from 'prosemirror-state'
 import type { ResolvedPos, Node as ProseMirrorNode } from 'prosemirror-model'
 import { TextSelection } from 'prosemirror-state'
-import { setBlockType } from 'prosemirror-commands'
+import { setBlockType, toggleMark } from 'prosemirror-commands'
 import { mimiriSchema } from './mimiri-schema'
 import { insertList } from './list-commands'
 import { serialize } from './mimiri-serializer'
@@ -282,7 +282,7 @@ function executeInsertHeading(state: EditorState, dispatch: (tr: Transaction) =>
 }
 
 /**
- * Insert a code block from the current selection
+ * Insert a code block from the current selection, or apply inline code mark for single-line selections
  */
 function executeInsertCodeBlock(
 	state: EditorState,
@@ -290,29 +290,50 @@ function executeInsertCodeBlock(
 	$from: ResolvedPos,
 	$to: ResolvedPos,
 ) {
+	const { from, to } = state.selection
+
+	// Check if selection is within a single paragraph (inline selection)
+	const isSameParagraph = $from.parent === $to.parent
+	const isInlineable = isSameParagraph && $from.parent.type.name === 'paragraph'
+	const hasSelection = from !== to
+
+	// If user has selected text within a single paragraph, check if it's single-line for inline code
+	if (hasSelection && isInlineable) {
+		const selectedText = state.doc.textBetween(from, to)
+		const isMultiLine = selectedText.includes('\n')
+
+		// For single-line selection, toggle inline code mark
+		if (!isMultiLine) {
+			const codeMark = mimiriSchema.marks.code
+			if (toggleMark(codeMark)(state, dispatch)) {
+				return
+			}
+		} else {
+			// Multi-line selection within single paragraph - create code block with selected text
+			const startPos = $from.before($from.depth)
+			const endPos = $to.after($to.depth)
+
+			const codeBlockMarkdown = '```\n' + selectedText + '\n```'
+			const parsedDoc = deserialize(codeBlockMarkdown)
+
+			const tr = state.tr.replaceWith(startPos, endPos, parsedDoc.content)
+			const newPos = startPos + 1
+			tr.setSelection(TextSelection.create(tr.doc, newPos))
+			dispatch(tr)
+			return
+		}
+	}
+
+	// Otherwise, insert a code block
 	// Get the range of selected blocks
 	const startPos = $from.before($from.depth)
 	const endPos = $to.after($to.depth)
 
-	// Collect nodes from the selection and serialize them to preserve markdown formatting
-	const nodes: any[] = []
-	state.doc.nodesBetween(startPos, endPos, (node, pos) => {
-		// Only collect top-level block nodes within the range
-		if (node.isBlock && pos >= startPos && pos < endPos) {
-			const parent = state.doc.resolve(pos).parent
-			if (parent.type.name === 'doc') {
-				nodes.push(node)
-				return false // Don't descend into children
-			}
-		}
-		return true
-	})
-
-	// Create a temporary doc with just the selected nodes to serialize
+	// If there's a selection, get the full text content from the affected blocks
 	let textContent = ''
-	if (nodes.length > 0) {
-		const tempDoc = mimiriSchema.nodes.doc.create({}, nodes)
-		textContent = serialize(tempDoc)
+	if (hasSelection) {
+		// Get all text from the selected block range
+		textContent = state.doc.textBetween(startPos, endPos, '\n', '\n')
 	}
 
 	// Wrap the content in code fence syntax and deserialize to get proper code block
@@ -327,4 +348,75 @@ function executeInsertCodeBlock(
 	tr.setSelection(TextSelection.create(tr.doc, newPos))
 
 	dispatch(tr)
+}
+
+/**
+ * Exit a code block by creating a new paragraph after it when pressing Enter on an empty line at the end.
+ * Only triggers if there's no content after the code block.
+ * Returns true if the command was applicable and executed.
+ */
+export function exitCodeBlock(state: EditorState, dispatch?: (tr: Transaction) => void): boolean {
+	const { $from, $to } = state.selection
+
+	// Only handle if cursor (not selection) is in a code block
+	if ($from.parent.type.name !== 'code_block' || $from.pos !== $to.pos) {
+		return false
+	}
+
+	// Check if there's any content after the code block
+	const codeBlockEnd = $from.after()
+	const docEnd = state.doc.content.size
+	const hasContentAfter = codeBlockEnd < docEnd - 1 // -1 because doc end position is after closing tag
+
+	// Only exit if there's no content after the code block
+	if (hasContentAfter) {
+		return false
+	}
+
+	// Check if we're at the end of the code block on an empty line
+	const codeBlock = $from.parent
+	const textContent = codeBlock.textContent
+	const cursorOffset = $from.parentOffset
+
+	// Check if the line we're on is empty (only whitespace or nothing after cursor to end)
+	const textAfterCursor = textContent.slice(cursorOffset)
+	const textBeforeCursor = textContent.slice(0, cursorOffset)
+	const lastNewline = textBeforeCursor.lastIndexOf('\n')
+	const currentLine = lastNewline >= 0 ? textBeforeCursor.slice(lastNewline + 1) : textBeforeCursor
+
+	// Exit if current line is empty (only whitespace) and we're at the end of the block or next line is empty
+	const currentLineEmpty = currentLine.trim() === ''
+	const atEndOfBlock = textAfterCursor === '' || textAfterCursor === '\n'
+
+	if (currentLineEmpty && atEndOfBlock) {
+		if (dispatch) {
+			// Remove the empty line from the code block if it exists
+			let codeBlockEnd = $from.after()
+			if (textAfterCursor === '\n') {
+				// Remove the trailing newline
+				const tr = state.tr.delete($from.pos, $from.pos + 1)
+				codeBlockEnd = tr.doc.resolve($from.pos).after()
+
+				// Insert a new paragraph after the code block
+				const paragraph = state.schema.nodes.paragraph.create()
+				tr.insert(codeBlockEnd, paragraph)
+
+				// Move cursor to the new paragraph
+				tr.setSelection(TextSelection.create(tr.doc, codeBlockEnd + 1))
+				dispatch(tr)
+			} else {
+				// Just insert a paragraph after the code block
+				const tr = state.tr
+				const paragraph = state.schema.nodes.paragraph.create()
+				tr.insert(codeBlockEnd, paragraph)
+
+				// Move cursor to the new paragraph
+				tr.setSelection(TextSelection.create(tr.doc, codeBlockEnd + 1))
+				dispatch(tr)
+			}
+		}
+		return true
+	}
+
+	return false
 }

--- a/src/services/editor/prosemirror/format-commands.ts
+++ b/src/services/editor/prosemirror/format-commands.ts
@@ -282,6 +282,22 @@ function executeInsertHeading(state: EditorState, dispatch: (tr: Transaction) =>
 }
 
 /**
+ * Find the depth of the top-level block (direct child of doc) containing the position.
+ * This ensures we replace entire blocks instead of nested content, which would break
+ * document structure rules (e.g., replacing a paragraph inside a list item).
+ */
+function getTopLevelBlockDepth($pos: ResolvedPos): number {
+	let depth = $pos.depth
+	while (depth > 0) {
+		if ($pos.node(depth - 1).type.name === 'doc') {
+			return depth
+		}
+		depth--
+	}
+	return 1 // Fallback to depth 1
+}
+
+/**
  * Insert a code block from the current selection, or apply inline code mark for single-line selections
  */
 function executeInsertCodeBlock(
@@ -292,12 +308,12 @@ function executeInsertCodeBlock(
 ) {
 	const { from, to } = state.selection
 
-	// Check if selection is within a single paragraph (inline selection)
+	// Check if selection is within a single text block (inline selection)
 	const isSameParagraph = $from.parent === $to.parent
-	const isInlineable = isSameParagraph && $from.parent.type.name === 'paragraph'
+	const isInlineable = isSameParagraph && $from.parent.type.name !== 'code_block'
 	const hasSelection = from !== to
 
-	// If user has selected text within a single paragraph, check if it's single-line for inline code
+	// If user has selected text within a single text block, check if it's single-line for inline code
 	if (hasSelection && isInlineable) {
 		const selectedText = state.doc.textBetween(from, to)
 		const isMultiLine = selectedText.includes('\n')
@@ -305,15 +321,18 @@ function executeInsertCodeBlock(
 		// For single-line selection, toggle inline code mark
 		if (!isMultiLine) {
 			const codeMark = mimiriSchema.marks.code
-			if (toggleMark(codeMark)(state, dispatch)) {
-				return
-			}
+			toggleMark(codeMark)(state, dispatch)
+			return
 		} else {
-			// Multi-line selection within single paragraph - create code block with selected text
-			const startPos = $from.before($from.depth)
-			const endPos = $to.after($to.depth)
+			// Multi-line selection within single paragraph - create code block preserving all paragraph text
+			const fromDepth = getTopLevelBlockDepth($from)
+			const toDepth = getTopLevelBlockDepth($to)
+			const startPos = $from.before(fromDepth)
+			const endPos = $to.after(toDepth)
 
-			const codeBlockMarkdown = '```\n' + selectedText + '\n```'
+			// Get all text from the block range to avoid losing unselected content
+			const textContent = state.doc.textBetween(startPos, endPos, '\n', '\n')
+			const codeBlockMarkdown = '```\n' + textContent + '\n```'
 			const parsedDoc = deserialize(codeBlockMarkdown)
 
 			const tr = state.tr.replaceWith(startPos, endPos, parsedDoc.content)
@@ -325,16 +344,14 @@ function executeInsertCodeBlock(
 	}
 
 	// Otherwise, insert a code block
-	// Get the range of selected blocks
-	const startPos = $from.before($from.depth)
-	const endPos = $to.after($to.depth)
+	// Get the range of selected blocks at the top-level block depth
+	const fromDepth = getTopLevelBlockDepth($from)
+	const toDepth = getTopLevelBlockDepth($to)
+	const startPos = $from.before(fromDepth)
+	const endPos = $to.after(toDepth)
 
-	// If there's a selection, get the full text content from the affected blocks
-	let textContent = ''
-	if (hasSelection) {
-		// Get all text from the selected block range
-		textContent = state.doc.textBetween(startPos, endPos, '\n', '\n')
-	}
+	// Get the full text content from the affected blocks (preserves content even with collapsed cursor)
+	const textContent = state.doc.textBetween(startPos, endPos, '\n', '\n')
 
 	// Wrap the content in code fence syntax and deserialize to get proper code block
 	const codeBlockMarkdown = '```\n' + textContent + '\n```'

--- a/src/services/editor/prosemirror/mimiri-input-rules.ts
+++ b/src/services/editor/prosemirror/mimiri-input-rules.ts
@@ -103,6 +103,33 @@ const urlInputRule = (markType: MarkType) => {
 	})
 }
 
+// Input rule for inline code with backticks
+const inlineCodeRule = (markType: MarkType) => {
+	// Match text surrounded by backticks: `code`
+	return new InputRule(/`([^`]+)`$/, (state, match, start, end) => {
+		const $start = state.doc.resolve(start)
+
+		// Don't apply in code blocks
+		if ($start.parent.type.spec.code) {
+			return null
+		}
+
+		// Check if we already have a code mark here
+		const hasCode = state.doc.rangeHasMark(start, end, markType)
+		if (hasCode) {
+			return null
+		}
+
+		const textContent = match[1]
+
+		return state.tr
+			.delete(start, start + 1) // Remove opening backtick
+			.delete(start + textContent.length, start + textContent.length + 1) // Remove closing backtick (adjusted for first deletion)
+			.addMark(start, start + textContent.length, markType.create())
+			.removeStoredMark(markType)
+	})
+}
+
 // Helper to convert URL at cursor position to link (used by Enter key handler)
 export const convertUrlAtCursor = (markType: MarkType) => {
 	return (state, dispatch) => {
@@ -148,6 +175,9 @@ export const mimiriInputRules = (schema: Schema) => {
 	let markType
 	if ((markType = schema.marks.link)) {
 		rules.push(urlInputRule(markType))
+	}
+	if ((markType = schema.marks.code)) {
+		rules.push(inlineCodeRule(markType))
 	}
 	return inputRules({ rules })
 }


### PR DESCRIPTION
Main Changes:

- Inline code formatting: Added support for inline code using backticks in both editors
- Ctrl+E shortcut: New keyboard shortcut with smart detection - applies inline code for single-line selections, inserts code blocks for multi-line
- Smart code button: Code block button now uses the same smart detection (inline code vs code block based on selection)
  - but always inserts a code block if no selection, there is no dedicated button for supporting inline code without a selection
- Various prosemirror code block theming related fixes

Example:
<img width="1833" height="341" alt="image" src="https://github.com/user-attachments/assets/46068bf6-41ff-4324-afa7-be9674946602" />
