### PR TITLE
useDevApi: no-op when the dev key pair is not baked

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "webclient-vue",
-	"version": "2.6.8",
+	"version": "2.6.9",
 	"minElectronVersionWin32": "2.6.1",
 	"minElectronVersionDarwin": "2.6.1",
 	"minElectronVersionLinux": "2.6.1",

--- a/src/global.ts
+++ b/src/global.ts
@@ -41,7 +41,12 @@ export const testMode = !!mimiriTestInfo
 // Deliberately a toggle between baked-in pairs rather than an injectable
 // key: accepting an arbitrary key from outside would let anyone who
 // controls the environment re-key the client.
-const useDevApi = !!mimiriTestInfo?.useDevApi
+// If the build didn't bake the dev pair (shell 2.6.14's bundle shipped
+// without it), the toggle no-ops instead of aiming at a host with an
+// undefined key — normal production behavior is the safe fallback, and
+// the e2e spec detects it from the traffic and skips.
+const useDevApi =
+	!!mimiriTestInfo?.useDevApi && !!env.VITE_DEV_API_PUBLIC_KEY && !!env.VITE_MIMER_DEV_API_HOST
 const host = mimiriTestInfo?.apiUrl ?? (useDevApi ? env.VITE_MIMER_DEV_API_HOST : env.VITE_MIMER_API_HOST)
 const paymentHost = env.VITE_PAYMENT_API_HOST
 const serverKey = useDevApi ? env.VITE_DEV_API_PUBLIC_KEY : env.VITE_API_PUBLIC_KEY


### PR DESCRIPTION
Follow-up to #46, prompted by shell 2.6.14: the release build's .env doesn't carry `VITE_DEV_API_PUBLIC_KEY(_ID)` and has a stale `VITE_MIMER_DEV_API_HOST` (`app-dev-aek`), so `MIMIRI_USE_DEV_API=1` pointed the renderer at an unreachable host with an undefined server key and the e2e staging-sync spec timed out on every leg.

With this guard the toggle simply no-ops when the dev pair isn't compiled in — normal production behavior is the safe fallback, and the e2e spec detects that from the traffic (availability check not going to dev-api) and skips with a clear reason.

For the toggle to actually engage, the **build environment's .env** needs, alongside the existing vars:

```
VITE_MIMER_DEV_API_HOST=https://dev-api.mimiri.io/api
VITE_DEV_API_PUBLIC_KEY_ID=20250110F67C334D
VITE_DEV_API_PUBLIC_KEY=<the dev public key, value in .env.example>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)